### PR TITLE
Make the slave_connection also thread local

### DIFF
--- a/lib/slavery.rb
+++ b/lib/slavery.rb
@@ -85,7 +85,7 @@ module Slavery
 
     # Create an anonymous AR class to hold slave connection
     def slave_connection_holder
-      @slave_connection_holder ||= Class.new(ActiveRecord::Base) {
+      Thread.current[:slavery_connection] ||= Class.new(ActiveRecord::Base) {
         self.abstract_class = true
 
         def self.name

--- a/lib/slavery/version.rb
+++ b/lib/slavery/version.rb
@@ -1,3 +1,3 @@
 module Slavery
-  VERSION = '1.4.1'
+  VERSION = '1.4.2'
 end

--- a/spec/slavery_spec.rb
+++ b/spec/slavery_spec.rb
@@ -81,14 +81,14 @@ describe Slavery do
   describe 'configuration' do
     before do
       # Backup connection and configs
-      @old_conn = User.instance_variable_get :@slave_connection_holder
+      @old_conn = Thread.current[:slavery_connection]
       @old_config = ActiveRecord::Base.configurations.dup
-      User.instance_variable_set :@slave_connection_holder, nil
+      Thread.current[:slavery_connection] = nil
     end
 
     after do
       # Restore connection and configs
-      User.instance_variable_set :@slave_connection_holder, @old_conn
+      Thread.current[:slavery_connection] = @old_conn
       ActiveRecord::Base.configurations = @old_config
     end
 

--- a/spec/slavery_spec.rb
+++ b/spec/slavery_spec.rb
@@ -105,4 +105,10 @@ describe Slavery do
       expect { Slavery.on_slave { User.count } }.to raise_error(Slavery::Error)
     end
   end
+
+  it "uses the same connection for all models" do
+    Slavery.on_slave do
+      User.connection.should == ActiveRecord::Base.connection
+    end
+  end
 end


### PR DESCRIPTION
Hi there:

I wanted to get your thoughts on this PR.  Basically, we made the slave_connection variable thread local for a couple reasons:

1) Within a thread, we are making multiple calls to the slave via different ActiveRecord classes (e.g. through `find_by_sql`).  Therefore, we didn't want to create a new slave connection each time.

2) Since the `Slavery#on_slave` method uses a thread variable, maintaining a single slave connection for the thread seemed to be consistent.

Appreciate your comments,
Jason
