### PR TITLE
Change Slavery.disabled to regular attribute

### DIFF
--- a/lib/slavery.rb
+++ b/lib/slavery.rb
@@ -16,9 +16,11 @@ module Slavery
 
   class Error < StandardError; end
 
-  mattr_accessor :disabled, :env, :spec_key
+  mattr_accessor :env, :spec_key
 
   class << self
+    attr_accessor :disabled
+
     def spec_key
       case @@spec_key
       when String   then @@spec_key

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,13 +20,17 @@ ActiveRecord::Base.configurations = {
 
 # Create two records on master
 ActiveRecord::Base.establish_connection(:test)
-ActiveRecord::Base.connection.create_table :users, force: true
+ActiveRecord::Base.connection.create_table :users, force: true do |t|
+  t.boolean :disabled
+end
 User.create
 User.create
 
 # Create one record on slave, emulating replication lag
 ActiveRecord::Base.establish_connection(:test_slave)
-ActiveRecord::Base.connection.create_table :users, force: true
+ActiveRecord::Base.connection.create_table :users, force: true do |t|
+  t.boolean :disabled
+end
 User.create
 
 # Reconnect to master


### PR DESCRIPTION
Slavery#disabled attribute confilct with model which has disabled
field.

> ActiveRecord::DangerousAttributeError: disabled is defined by Active
> Record. Check to make sure that you don't have an attribute or method
> with the same name.

There is no reason to make it module attribute because it is accessed as `Slavery.disabled`, and no reason to access it like `User.first.disabled`
