### PR TITLE
Rails 3.2 Compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: ruby
+
+rvm:
+ - 2.2.2
+ - 2.3.3
+
+gemfile:
+  - Gemfile
+  - gemfiles/rails3.2.gemfile
+  - gemfiles/rails4.gemfile
+  - gemfiles/rails4.2.gemfile
+
+script: bundle exec rspec spec

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Slavery - Simple, conservative slave reads for ActiveRecord
 
+[![Build Status](https://travis-ci.org/citrus/slavery.svg?branch=rails3.2)](https://travis-ci.org/citrus/slavery)
+
 Slavery is a simple, easy to use gem for ActiveRecord that enables conservative slave reads, which means it doesn't automatically redirect all SELECTs to slaves.
 
 Instead, you can do `Slavery.on_slave { User.count }` to send a particular query to a slave.

--- a/gemfiles/rails3.2.gemfile
+++ b/gemfiles/rails3.2.gemfile
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+gem 'activerecord', '~> 3.2'
+
+group :development, :test do
+  gem 'test-unit', '~> 3.0'
+end
+
+gemspec :path => '../'

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem 'activerecord', '~> 4.2'
+
+gemspec :path => '../'

--- a/gemfiles/rails4.gemfile
+++ b/gemfiles/rails4.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem 'activerecord', '~> 4.0.0'
+
+gemspec :path => '../'

--- a/lib/slavery.rb
+++ b/lib/slavery.rb
@@ -12,9 +12,12 @@ module Slavery
     attr_writer :spec_key
 
     def spec_key
-      case @spec_key
-      when String   then @spec_key
-      when NilClass then @spec_key = "#{ActiveRecord::ConnectionHandling::RAILS_ENV.call}_slave"
+      @spec_key ||= if defined?(ActiveRecord::ConnectionHandling::RAILS_ENV)
+        "#{ActiveRecord::ConnectionHandling::RAILS_ENV.call}_slave"
+      elsif env = (Rails.env if defined?(Rails.env)) || ENV["RAILS_ENV"] || ENV["RACK_ENV"]
+        "#{env}_slave"
+      else
+        raise Error.new('Slavery.spec_key invalid!')
       end
     end
 

--- a/lib/slavery.rb
+++ b/lib/slavery.rb
@@ -4,6 +4,7 @@ require 'slavery/error'
 require 'slavery/slave_connection_holder'
 require 'slavery/version'
 require 'slavery/active_record/base'
+require 'slavery/active_record/connection_handling'
 require 'slavery/active_record/relation'
 
 module Slavery
@@ -12,13 +13,7 @@ module Slavery
     attr_writer :spec_key
 
     def spec_key
-      @spec_key ||= if defined?(ActiveRecord::ConnectionHandling::RAILS_ENV)
-        "#{ActiveRecord::ConnectionHandling::RAILS_ENV.call}_slave"
-      elsif env = (Rails.env if defined?(Rails.env)) || ENV["RAILS_ENV"] || ENV["RACK_ENV"]
-        "#{env}_slave"
-      else
-        raise Error.new('Slavery.spec_key invalid!')
-      end
+      @spec_key ||= "#{ActiveRecord::ConnectionHandling::RAILS_ENV.call}_slave"
     end
 
     def on_slave(&block)

--- a/lib/slavery/active_record/connection_handling.rb
+++ b/lib/slavery/active_record/connection_handling.rb
@@ -1,0 +1,6 @@
+module ActiveRecord
+  module ConnectionHandling
+    # Already defined in Rails 4.1+
+    RAILS_ENV ||= -> { (Rails.env if defined?(Rails.env)) || ENV["RAILS_ENV"] || ENV["RACK_ENV"] }
+  end
+end


### PR DESCRIPTION
I wasn't able to use Slavery 2.0.0 on Rails 3.2 as I got the following when trying to open a db connection:

```
> Slavery::SlaveConnectionHolder.activate
NameError: uninitialized constant ActiveRecord::ConnectionHandling
from /Users/Spencer/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/slavery-2.0.0/lib/slavery.rb:19:in `spec_key'
```

It seems ActiveRecord::ConnectionHandling was introduced in Rails 4.

This PR rewrites Slavery.spec_key to use `Rails.env` for previous versions of rails.