### PR TITLE
Allow url formatted db connections.

### DIFF
--- a/lib/slavery/slave_connection_holder.rb
+++ b/lib/slavery/slave_connection_holder.rb
@@ -5,8 +5,9 @@ module Slavery
     class << self
       # for delayed activation
       def activate
-        raise Error.new('Slavery.spec_key invalid!') unless ActiveRecord::Base.configurations[Slavery.spec_key]
-        establish_connection Slavery.spec_key.to_sym
+        spec = ActiveRecord::Base.configurations[Slavery.spec_key]
+        raise Error.new('Slavery.spec_key invalid!') if spec.nil?
+        establish_connection spec
       end
     end
   end

--- a/spec/slavery_spec.rb
+++ b/spec/slavery_spec.rb
@@ -120,5 +120,25 @@ describe Slavery do
 
       expect(Slavery.on_slave { User.count }).to be 2
     end
+
+    it 'connects to slave when specified as a hash' do
+      Slavery.spec_key = 'test_slave'
+      hash = ActiveRecord::Base.configurations['test_slave']
+      expect(Slavery::SlaveConnectionHolder).to receive(:establish_connection).with(hash)
+      Slavery::SlaveConnectionHolder.activate
+    end
+
+    it 'connects to slave when specified as a url' do
+      parsed_url = {
+        'adapter'  => 'postgresql',
+        'username' => 'root',
+        'port'     => 5432,
+        'database' => 'test_slave',
+        'host'     => 'localhost'
+      }
+      Slavery.spec_key = 'test_slave_url'
+      expect(Slavery::SlaveConnectionHolder).to receive(:establish_connection).with(parsed_url)
+      Slavery::SlaveConnectionHolder.activate
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,8 +6,9 @@ ENV['RACK_ENV'] = 'test'
 require 'slavery'
 
 ActiveRecord::Base.configurations = {
-  'test' =>        { adapter: 'sqlite3', database: 'test_db' },
-  'test_slave' =>  { adapter: 'sqlite3', database: 'test_slave_db' }
+  'test' =>            { adapter: 'sqlite3', database: 'test_db' },
+  'test_slave'     =>  { adapter: 'sqlite3', database: 'test_slave_db' },
+  'test_slave_url' => "postgres://root:@localhost:5432/test_slave"
 }
 
 # Prepare databases


### PR DESCRIPTION
I had trouble using a database URL in my database.yml

```yaml
development:
  adapter: postgresql
  database: master-db

development_slave: <%= ENV['READONLY_DATABASE_URL'] %>
```

This patch allows the connection to be activated using URL or hash syntax.