### PR TITLE
Corrects transactional fixture check for Rails 5

### DIFF
--- a/lib/slavery/transaction.rb
+++ b/lib/slavery/transaction.rb
@@ -1,16 +1,20 @@
 module Slavery
   class Transaction
+    # The methods on ActiveSupport::TestCase which can potentially be used
+    # to determine if transactional fixtures are enabled
+    TEST_CONFIG_METHODS = [
+      :use_transactional_tests,
+      :use_transactional_fixtures
+    ]
+
     class << self
       def base_depth
-        @base_depth ||= begin
-          testcase = ActiveSupport::TestCase
-          if defined?(testcase) &&
-              testcase.respond_to?(:use_transactional_fixtures) &&
-              testcase.try(:use_transactional_fixtures)
-            1
-          else
-            0
-          end
+        @base_depth ||= if defined?(ActiveSupport::TestCase) &&
+          TEST_CONFIG_METHODS.any? { |m| ActiveSupport::TestCase.try(m) }
+        then
+          1
+        else
+          0
         end
       end
     end

--- a/lib/slavery/transaction.rb
+++ b/lib/slavery/transaction.rb
@@ -10,12 +10,19 @@ module Slavery
     class << self
       def base_depth
         @base_depth ||= if defined?(ActiveSupport::TestCase) &&
-          TEST_CONFIG_METHODS.any? { |m| ActiveSupport::TestCase.try(m) }
+          transactional_fixtures_enabled?
         then
           1
         else
           0
         end
+      end
+
+      private
+
+      def transactional_fixtures_enabled?
+        config = ActiveSupport::TestCase
+        TEST_CONFIG_METHODS.any? {|m| config.respond_to?(m) and config.send(m) }
       end
     end
   end


### PR DESCRIPTION
In Rails 5 `ActiveSupport::TestCase` now uses `use_transactional_tests`
rather than `use_transactional_fixtures` as its method to check whether
transactional fixtures are being utilized for the current test.

See: https://github.com/rails/rails/pull/19282

I'm in the middle of a Rails 5 upgrade on an app using Slavery and this was causing
```
      Slavery::Error:
        on_slave cannot be used inside transaction block!
```
when using `Slavery.on_slave`.