### PR TITLE
Note about removal of Slavery.spec_key= from version 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ putting the following in `test/test_helper.rb`
 Slavery.disabled = true
 ```
 
+## Upgrading from version 2 to version 3
+
+Please note that `Slavery.spec_key=` method has been removed from version 3.
+
 ## Support for non-Rails apps
 
 If you're using ActiveRecord in a non-Rails app (e.g. Sinatra), be sure to set `RACK_ENV` environment variable in the boot sequence, then:


### PR DESCRIPTION
@kenn feel free to update the messaging / let me know how you want to message it? I do think its necessary for the `README` to reflect the breaking upgrade change.