### PR TITLE
Add a deprecation warning on usage of `Slavery.spec_key=` interface

### DIFF
--- a/lib/slavery.rb
+++ b/lib/slavery.rb
@@ -12,7 +12,11 @@ require 'slavery/active_record/log_subscriber'
 module Slavery
   class << self
     attr_accessor :disabled
-    attr_writer :spec_key
+
+    def spec_key=(key)
+      ActiveSupport::Deprecation.warn("Slavery.spec_key= is deprecated and will be removed from v3")
+      @spec_key = key
+    end
 
     def spec_key
       @spec_key ||= "#{ActiveRecord::ConnectionHandling::RAILS_ENV.call}_slave"

--- a/lib/slavery/version.rb
+++ b/lib/slavery/version.rb
@@ -1,3 +1,3 @@
 module Slavery
-  VERSION = '2.1.1'
+  VERSION = '2.2.0'
 end


### PR DESCRIPTION
This needs to go on a separate branch `v2.2.0` not on master branch?